### PR TITLE
Accept list for ylevels in tabmulti

### DIFF
--- a/R/tabmulti.R
+++ b/R/tabmulti.R
@@ -136,8 +136,13 @@ tabmulti <- function(formula = NULL,
   if (! is.null(xlevels) && ! is.character(xlevels)) {
     stop("The input 'xlevels' must be a character vector.")
   }
-  if (! is.null(ylevels) && ! is.character(ylevels)) {
-    stop("The input 'ylevels' must be a character vector.")
+  if (! is.null(ylevels) && ! is.character(ylevels) &&
+      (is.list(ylevels) &&
+       (!all(vapply(ylevels, is.character, logical(1))) ||
+        length(ylevels) != sum(ymeasures == "freq")))) {
+    stop("The input 'ylevels' must be a character vector or ",
+         "list of character vectors with as much elements as ",
+         "'freq' in 'ymeasures'.")
   }
   if (! is.null(indent.spaces) && ! (is.numeric(indent.spaces) && indent.spaces >= 0 && indent.spaces == as.integer(indent.spaces))) {
     stop("The input 'indent.spaces' must be a non-negative integer.")


### PR DESCRIPTION
Dear Dane,

thanks for your great `tab` package.

I tried to produce a classical *table one* for a medical journal with the `tabmulti`
function. If I specified the `ylevels` for more than one categorial
variable I got the error: "The input 'ylevels' must be a character vector."

According to the manual page `ylevels` could be a
"... list of character vectors with labels for the levels of each
categorical ‘y’ variable."

This PR accepts a `list` for `ylevels` and additionally checks that the `ylevels` has the same length as `"freq"` ocurres in `ymeasures`.

Please find a minimal example below:

```r
library("tab")
data("mtcars")

tabmulti(
    cyl + vs ~ am,
    data = mtcars,
    ymeasure = c("freq", "freq"),
    ylevels = list(
        cyl = as.character(c(4, 6, 8)),
        vs = c("V-shaped", "straight")
    )
)

#            Variable         0        1     P
# 1        cyl, n (%)                    0.009
# 2        \\ \\ \\ 4  3 (15.8) 8 (61.5)
# 3        \\ \\ \\ 6  4 (21.1) 3 (23.1)
# 4        \\ \\ \\ 8 12 (63.2) 2 (15.4)
# 5         vs, n (%)                     0.34
# 6 \\ \\ \\ V-shaped 12 (63.2) 6 (46.2)
# 7 \\ \\ \\ straight  7 (36.8) 7 (53.8)
